### PR TITLE
Allow access to the data bag via the symbol form as well as the string form

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby
+rvm:
+  - "1.9.3-p551"
+  - "2.0.0-p598"
+  - "2.1.5"
+install: bundle install --binstubs
+env: TRAVIS_BUILD=true

--- a/History.md
+++ b/History.md
@@ -1,5 +1,12 @@
 # Changelog for chef-vault-testfixtures
 
+## 0.1.2
+
+* allow access to the data bag via the symbol form as well as the string form
+* re-organize the README to make the summary extracted by Hoe smaller
+* add Travis-CI integration and badging
+* add Code Climate integration and badging
+
 ## 0.1.1
 
 * fix disconnect between docs and code for shared context method

--- a/README.md
+++ b/README.md
@@ -2,11 +2,16 @@
 
 * home :: https://github.com/Nordstrom/chef-vault-testfixtures
 * license :: [Apache2](http://www.apache.org/licenses/LICENSE-2.0)
+* gem version :: [![Gem Version](https://badge.fury.io/rb/chef-vault-testfixtures.png)](http://badge.fury.io/rb/chef-vault-testfixtures)
+* build status :: [![Build Status](https://travis-ci.org/Nordstrom/chef-vault-testfixtures.png?branch=master)](https://travis-ci.org/Nordstrom/chef-vault-testfixtures)
+* code climate :: [![Code Climate](https://codeclimate.com/github/Nordstrom/chef-vault-testfixtures/badges/gpa.svg)](https://codeclimate.com/github/Nordstrom/chef-vault-testfixtures)
 
 ## DESCRIPTION
 
 chef-vault-testfixtures provides an RSpec shared context that
 dynamically stubs access to chef-vault encrypted data bags.
+
+## USAGE
 
 chef-vault is a gem to manage distribution and control of keys to
 decrypt Chef encrypted data bags.
@@ -32,7 +37,7 @@ Attempts to access secrets that would not be available to a node
 during a real chef-client run will not be mocked, which will cause
 the double to raise an 'unexpected message received' error.
 
-## SYNOPSIS
+## USAGE
 
 In the file `spec/support/chef-vault/test_fixtures/foo.rb`:
 

--- a/chef-vault-testfixtures.gemspec
+++ b/chef-vault-testfixtures.gemspec
@@ -1,15 +1,15 @@
 # -*- encoding: utf-8 -*-
-# stub: chef-vault-testfixtures 0.1.1.20150222214141 ruby lib
+# stub: chef-vault-testfixtures 0.1.2.20150224090711 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "chef-vault-testfixtures"
-  s.version = "0.1.1.20150222214141"
+  s.version = "0.1.2.20150224090711"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["James FitzGibbon"]
-  s.date = "2015-02-23"
-  s.description = "chef-vault-testfixtures provides an RSpec shared context that\ndynamically stubs access to chef-vault encrypted data bags.\n\nchef-vault is a gem to manage distribution and control of keys to\ndecrypt Chef encrypted data bags.\n\nWhen testing a cookbook that uses chef-vault, encryption is generally\nout of scope, which results in a large amount of stubs or mocks so that you get back fixture data without performing decryption.\n\nThis gem makes testing Chef cookbooks easier using ChefSpec by\ndynamically stubbing attempts to access vault data to return invalid\n(i.e. not real passwords for any of your environments) that are properly\nformatted (e.g. a vault item containing an RSA key really contains one)\n\nThe intended use case is that for each group of distinct secrets\n(e.g. an application stack, or a development team) you create one or\nmore plugins.  The plugins contain data that is specific to your\napplication.\n\nSince plugins can be whitelisted or blacklisted when the shared\ncontext is created, this makes it easy to only include the appropriate\nsecrets in a given cookbook's tests.\n\nAttempts to access secrets that would not be available to a node\nduring a real chef-client run will not be mocked, which will cause\nthe double to raise an 'unexpected message received' error."
+  s.date = "2015-02-24"
+  s.description = "chef-vault-testfixtures provides an RSpec shared context that\ndynamically stubs access to chef-vault encrypted data bags."
   s.email = ["james.i.fitzgibbon@nordstrom.com"]
   s.extra_rdoc_files = ["History.md", "Manifest.txt", "README.md"]
   s.files = [".rspec", ".rubocop.yml", ".yardopts", "Gemfile", "Guardfile", "History.md", "Manifest.txt", "README.md", "Rakefile", "chef-vault-testfixtures.gemspec", "lib/chef-vault/test_fixtures.rb", "lib/hoe/markdown.rb", "spec/lib/chef-vault/test_fixtures_spec.rb", "spec/spec_helper.rb", "spec/support/chef-vault/test_fixtures/bar.rb", "spec/support/chef-vault/test_fixtures/foo.rb"]
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.licenses = ["apache2"]
   s.rdoc_options = ["--main", "README.md"]
   s.rubygems_version = "2.4.4"
-  s.summary = "chef-vault-testfixtures provides an RSpec shared context that dynamically stubs access to chef-vault encrypted data bags"
+  s.summary = "chef-vault-testfixtures provides an RSpec shared context that dynamically stubs access to chef-vault encrypted data bags."
 
   if s.respond_to? :specification_version then
     s.specification_version = 4

--- a/lib/chef-vault/test_fixtures.rb
+++ b/lib/chef-vault/test_fixtures.rb
@@ -6,7 +6,7 @@ require 'little-plugger'
 class ChefVault
   # dynamic RSpec contexts for cookbooks that use chef-vault
   class TestFixtures
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
 
     extend LittlePlugger path: 'chef-vault/test_fixtures',
                          module: ChefVault::TestFixtures
@@ -41,7 +41,13 @@ class ChefVault
                 plugin.send(item).each do |k, v|
                   allow(fakevault).to receive(:[]).with(k).and_return(v)
                 end
-                # stub chef-vault to return the fake vault
+                # stub chef-vault to return the fake vault, via both symbol
+                # and string forms of the data bag name
+                allow(ChefVault::Item).to(
+                  receive(:load)
+                  .with(vaultname, item.to_s)
+                  .and_return(fakevault)
+                )
                 allow(ChefVault::Item).to(
                   receive(:load)
                   .with(vaultname.to_s, item.to_s)

--- a/spec/lib/chef-vault/test_fixtures_spec.rb
+++ b/spec/lib/chef-vault/test_fixtures_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe ChefVault::TestFixtures do
       expect(baz).to eq(2)
     end
 
+    it 'it should allow access to foo/bar via a symbol instead of a string' do
+      ChefVault::TestFixtures.plugins
+      baz = ChefVault::Item.load(:foo, 'bar')['baz']
+      expect(baz).to eq(2)
+    end
+
     it 'it should stub the bar/foo vault item' do
       ChefVault::TestFixtures.plugins
       baz = ChefVault::Item.load('bar', 'foo')['baz']
@@ -89,6 +95,13 @@ RSpec.describe ChefVault::TestFixtures do
       ChefVault::TestFixtures.plugins
       item1 = ChefVault::Item.load('bar', 'foo')
       item2 = ChefVault::Item.load('bar', 'gzonk')
+      expect(item1['baz']).to eq(item2['baz'])
+    end
+
+    it 'should allow access to the aliased bar/gzonk vault item via a symbol' do
+      ChefVault::TestFixtures.plugins
+      item1 = ChefVault::Item.load(:bar, 'foo')
+      item2 = ChefVault::Item.load(:bar, 'gzonk')
       expect(item1['baz']).to eq(item2['baz'])
     end
 


### PR DESCRIPTION
Allow access to the data bag via the symbol form as well as the string form
Re-organize the README to make the summary extracted by Hoe smaller
Add Travis-CI integration and badging
Add Code Climate integration and badging
Add Gem version badging
Closes #1