### PR TITLE
Move chef from runtime to development dependency

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Changelog for chef-vault-testfixtures
 
+## 0.2.0
+
+* move chef dependency out of runtime and into development - rubygems 1.8.x (which chef-client shipped with prior to 11.8.0) has major problems now that Chef v11 and v12 are both available
+
 ## 0.1.3
 
 * change chef runtime dependency from >= 11.14 to >= 11.0

--- a/README.md
+++ b/README.md
@@ -191,6 +191,24 @@ A [companion cookbook](https://supermarket.chef.io/cookbooks/chef_vault_testfixt
 is also available that uses the same data to populate vaults during
 Test Kitchen integration runs.
 
+## DEPENDENCIES
+
+It may seem strange that chef isn't a runtime dependency of this gem.
+This is due to idiosyncracies in the way that old versions of rubygems
+(such as those that ship with chef-client prior to 11.18.0) process
+dependencies.
+
+If we include chef as a dependency, even with a relaxed requirement
+like '>= 11.0', rubygems v1.8.x will still try to pull in chef-12.0.3,
+even if the --conservative switch is used.  This in turn pulls in
+Ohai 8.1.x, which doesn't work under Ruby 1.9.3 (which is what chef-client
+11 embeds).
+
+rubygems v2.x.x do not suffer from this problem.  The net takeaway is that
+attempting to install this gem on a system that does not have chef installed
+will fail.  I expect the instances of people trying to do this to be
+small.
+
 ## AUTHOR
 
 James FitzGibbon - james.i.fitzgibbon@nordstrom.com - @jf647

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ begin
     extra_deps << ['rspec', '~> 3.1']
     extra_deps << ['chef-vault', '~> 2.5']
     extra_deps << ['little-plugger', '~> 1.1']
-    extra_deps << ['chef', '>= 11.0']
+    extra_dev_deps << ['chef', '~> 12.0']
     extra_dev_deps << ['hoe', '~> 3.13']
     extra_dev_deps << ['hoe-gemspec', '~> 1.0']
     extra_dev_deps << ['rake', '~> 10.3']

--- a/chef-vault-testfixtures.gemspec
+++ b/chef-vault-testfixtures.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
-# stub: chef-vault-testfixtures 0.1.3.20150225104151 ruby lib
+# stub: chef-vault-testfixtures 0.2.0.20150225121503 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "chef-vault-testfixtures"
-  s.version = "0.1.3.20150225104151"
+  s.version = "0.2.0.20150225121503"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
@@ -26,8 +26,8 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<rspec>, ["~> 3.1"])
       s.add_runtime_dependency(%q<chef-vault>, ["~> 2.5"])
       s.add_runtime_dependency(%q<little-plugger>, ["~> 1.1"])
-      s.add_runtime_dependency(%q<chef>, [">= 11.0"])
       s.add_development_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_development_dependency(%q<chef>, ["~> 12.0"])
       s.add_development_dependency(%q<hoe>, ["~> 3.13"])
       s.add_development_dependency(%q<hoe-gemspec>, ["~> 1.0"])
       s.add_development_dependency(%q<rake>, ["~> 10.3"])
@@ -46,8 +46,8 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rspec>, ["~> 3.1"])
       s.add_dependency(%q<chef-vault>, ["~> 2.5"])
       s.add_dependency(%q<little-plugger>, ["~> 1.1"])
-      s.add_dependency(%q<chef>, [">= 11.0"])
       s.add_dependency(%q<rdoc>, ["~> 4.0"])
+      s.add_dependency(%q<chef>, ["~> 12.0"])
       s.add_dependency(%q<hoe>, ["~> 3.13"])
       s.add_dependency(%q<hoe-gemspec>, ["~> 1.0"])
       s.add_dependency(%q<rake>, ["~> 10.3"])
@@ -67,8 +67,8 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rspec>, ["~> 3.1"])
     s.add_dependency(%q<chef-vault>, ["~> 2.5"])
     s.add_dependency(%q<little-plugger>, ["~> 1.1"])
-    s.add_dependency(%q<chef>, [">= 11.0"])
     s.add_dependency(%q<rdoc>, ["~> 4.0"])
+    s.add_dependency(%q<chef>, ["~> 12.0"])
     s.add_dependency(%q<hoe>, ["~> 3.13"])
     s.add_dependency(%q<hoe-gemspec>, ["~> 1.0"])
     s.add_dependency(%q<rake>, ["~> 10.3"])

--- a/lib/chef-vault/test_fixtures.rb
+++ b/lib/chef-vault/test_fixtures.rb
@@ -6,7 +6,7 @@ require 'little-plugger'
 class ChefVault
   # dynamic RSpec contexts for cookbooks that use chef-vault
   class TestFixtures
-    VERSION = '0.1.3'
+    VERSION = '0.2.0'
 
     extend LittlePlugger path: 'chef-vault/test_fixtures',
                          module: ChefVault::TestFixtures
@@ -43,7 +43,7 @@ class ChefVault
                 end
                 # stub chef-vault to return the fake vault, via both symbol
                 # and string forms of the data bag name
-                [ vaultname, vaultname.to_s ].each do |data_bag|
+                [vaultname, vaultname.to_s].each do |data_bag|
                   allow(ChefVault::Item).to(
                     receive(:load)
                     .with(data_bag, item.to_s)


### PR DESCRIPTION
 to allow compatibility with old chef-clients (see README for full explanation)
Version bump to 0.2.0