### PR TITLE
Add compat with chef-vault cookbook helper ~> 1.3

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # Changelog for chef-vault-testfixtures
 
+## 0.4.0
+
+* add stubs for Chef::DataBagItem.load and Chef::DataBag.load for compatibility with code that probes the data bag to determine if it is a vault (e.g. chef-vault cookbook ~> 1.3)
+
 ## 0.3.0
 
 * completely re-work to use JSON data bag files in test/integration for compatibility with the fallback mechanism in the chef-vault cookbook

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ The recipe that the example tests:
 The helper will call `ChefVault::Item.load`, which will be stubbed using
 the data bag from the test/integration/data_bags directory.
 
+## VAULT PROBING
+
+Some recipes and helpers attempt to determine if a data bag is a vault
+by checking the raw data bag item to see if one of the values contains
+encrypted data, then checking for the existence of the `_keys` data bag
+item to go along with the normal item.  The [sensu cookbook](https://github.com/sensu/sensu-chef/blob/35ee3aa6fa4ad578cdf751fe6822e3d2b3890d94/libraries/sensu_helpers.rb#L39-55) is a good example
+of this:
+
+The helper also stubs these methods, so that the probe mechanism should
+consider the data bag to be a vault and call ChefVault::Item.load, which
+is stubbed as described above.
+
 ## DEPENDENCIES
 
 It may seem strange that chef isn't a runtime dependency of this gem.

--- a/chef-vault-testfixtures.gemspec
+++ b/chef-vault-testfixtures.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: chef-vault-testfixtures 0.3.0.20150417141427 ruby lib
+# stub: chef-vault-testfixtures 0.4.0.20150424123749 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "chef-vault-testfixtures"
-  s.version = "0.3.0.20150417141427"
+  s.version = "0.4.0.20150424123749"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["James FitzGibbon"]
-  s.date = "2015-04-17"
+  s.date = "2015-04-24"
   s.description = "chef-vault-testfixtures provides an RSpec shared context that\nstubs access to chef-vault encrypted data bags using the same\nfallback mechanism as the `chef_vault_item` helper from the\n[chef-vault cookbook](https://supermarket.chef.io/cookbooks/chef-vault)"
   s.email = ["james.i.fitzgibbon@nordstrom.com"]
   s.extra_rdoc_files = ["History.md", "Manifest.txt", "README.md"]

--- a/spec/lib/chef-vault/test_fixtures_spec.rb
+++ b/spec/lib/chef-vault/test_fixtures_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ChefVault::TestFixtures do
     end
   end
 
-  describe 'Stub a Vault' do
+  describe 'stub ChefVault::Item.load' do
     it 'should stub the foo/bar vault item' do
       baz = ChefVault::Item.load('foo', 'bar')['baz']
       expect(baz).to eq(2)
@@ -77,6 +77,23 @@ RSpec.describe ChefVault::TestFixtures do
     it 'should allow and ignore an attempt to save' do
       item = ChefVault::Item.load('bar', 'foo')
       item.save
+    end
+  end
+
+  describe 'stub Chef::DataBagItem.load' do
+    it 'should present the foo/bar data bag item as encrypted' do
+      dbi = Chef::DataBagItem.load('foo', 'bar')
+      encrypted = dbi.detect do |_, v|\
+        v.is_a?(Hash) && v.key?('encrypted_data')
+      end
+      expect(encrypted).to be_truthy
+    end
+  end
+
+  describe 'stub Chef::DataBag.load' do
+    it 'should fake the foo/bar_keys data bag item' do
+      db = Chef::DataBag.load('foo')
+      expect(db.key?('bar_keys')).to be_truthy
     end
   end
 end


### PR DESCRIPTION
add stubs for Chef::DataBagItem.load and Chef::DataBag.load for compatibility with code that probes the data bag to determine if it is a vault (e.g. chef-vault cookbook ~> 1.3)
Version bump to 0.4.0